### PR TITLE
fix(coupons): handle nullable expiresAt and improve update logic

### DIFF
--- a/src/controllers/coupons/index.ts
+++ b/src/controllers/coupons/index.ts
@@ -48,7 +48,7 @@ export class CouponController {
 
       const newObject = await this.model.create({ data: result.data })
       res.status(201).send({
-        newObject,
+        coupon: newObject,
         message: 'Cupón creado correctamente',
       })
     } catch (error) {

--- a/src/models/Coupon/index.ts
+++ b/src/models/Coupon/index.ts
@@ -54,16 +54,16 @@ export class CouponModel {
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         if (error.code === 'P2002') {
-          throw new ConflictError('La categoría ya existe')
+          throw new ConflictError('El cupón ya existe')
         }
       }
       if (error instanceof AppError) throw error
-      throw new ServerError('Error al intentar crear la categoría')
+      throw new ServerError('Error al intentar crear el cupón')
     }
   }
 
   static async update({ id, data }: { id: string; data: Partial<CouponUpdateType> }) {
-    const newData = getDataForUpdate(data)
+    const newData = getDataForUpdate(data, ['expiresAt'])
 
     try {
       const coupon = await prisma.coupon.findUnique({ where: { id } })

--- a/src/models/Product/index.ts
+++ b/src/models/Product/index.ts
@@ -94,7 +94,6 @@ export class ProductModel {
 
       return { objects, totalItems }
     } catch (error) {
-      console.log(error)
       if (error instanceof AppError) throw error
       throw new ServerError('Errror al intentar obtener los productos')
     }

--- a/src/schemas/coupons/index.ts
+++ b/src/schemas/coupons/index.ts
@@ -15,7 +15,8 @@ export const CouponSchema = z.object({
     .optional(),
   expiresAt: z
     .string()
-    .transform((val) => new Date(val))
+    .nullable()
+    .transform((val) => (val ? new Date(val) : null))
     .optional(),
 })
 

--- a/src/utils/getDataForUpdate.ts
+++ b/src/utils/getDataForUpdate.ts
@@ -1,7 +1,9 @@
-export const getDataForUpdate = (data: object) => {
+export const getDataForUpdate = (data: object, keysExcept: string[] = []) => {
   return Object.entries(data).reduce(
     (acc, [key, value]) => {
-      if (value !== undefined) acc[key] = value
+      if (value !== undefined || keysExcept.includes(key)) {
+        acc[key] = value
+      }
       return acc
     },
     {} as Record<string, unknown>,


### PR DESCRIPTION
- Make expiresAt field nullable in CouponSchema
- Include specific keys in getDataForUpdate to preserve null values
- Update error messages to correctly reference coupons instead of categories
- Rename newObject to coupon in response for clarity