### PR TITLE
refactor(Product): rename categoriesIds to categoriesId for consistency

### DIFF
--- a/src/controllers/products/index.ts
+++ b/src/controllers/products/index.ts
@@ -47,8 +47,8 @@ export class ProductsController {
       req.query.priceRange as string | string[] | undefined,
       Number,
     )
-    const categoriesIds = parseQueryArray(
-      req.query.categoriesIds as string | string[] | undefined,
+    const categoriesId = parseQueryArray(
+      req.query.categoriesId as string | string[] | undefined,
       String,
     )
     const unitiesIds = parseQueryArray(
@@ -64,7 +64,7 @@ export class ProductsController {
         offset,
         limit: numericLimit,
         search,
-        categoriesIds,
+        categoriesId,
         unitiesIds,
         priceRange,
         inStockOnly: inStockOnly === undefined ? undefined : inStockOnly === 'true',

--- a/src/models/Product/index.ts
+++ b/src/models/Product/index.ts
@@ -42,7 +42,7 @@ export class ProductModel {
 
   static async getAll(params: ProductFilterParams) {
     const search = params.search ?? ''
-    const categoriesIds = params.categoriesIds ?? []
+    const categoriesId = params.categoriesId ?? []
     const unitiesIds = params.unitiesIds ?? []
     const priceRange = params.priceRange ?? []
     const inStockOnly = params.inStockOnly
@@ -55,8 +55,8 @@ export class ProductModel {
         whereClause.name = { contains: search, mode: 'insensitive' }
       }
 
-      if (categoriesIds && categoriesIds.length > 0) {
-        whereClause.categoryId = { in: categoriesIds }
+      if (categoriesId && categoriesId.length > 0) {
+        whereClause.categoryId = { in: categoriesId }
       }
 
       if (unitiesIds && unitiesIds.length > 0) {

--- a/src/types/Product/index.d.ts
+++ b/src/types/Product/index.d.ts
@@ -1,7 +1,7 @@
 import { BaseFilterParams } from '../shared'
 
 export interface ProductFilterParams extends BaseFilterParams {
-  categoriesIds?: string[]
+  categoriesId?: string[]
   unitiesIds?: string[]
   priceRange?: number[]
   inStockOnly?: boolean


### PR DESCRIPTION
The parameter name was changed to match the singular form used in the database schema (categoryId) to maintain consistency across the codebase.