### PR TITLE
feat(products): add manual product order update endpoint

### DIFF
--- a/src/controllers/products/index.ts
+++ b/src/controllers/products/index.ts
@@ -169,6 +169,30 @@ export class ProductsController {
     }
   }
 
+  updateOrderManual = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params
+      const { displayOrder } = req.body
+
+      if (typeof id !== 'string' || typeof displayOrder !== 'number') {
+        res.status(400).json({
+          error:
+            'El cuerpo de la solicitud debe contener un "id" (string) y un "displayOrder" (number)',
+        })
+        return
+      }
+
+      const result = await this.model.updateSingleOrder({ id, displayOrder })
+
+      res.status(200).json({
+        message: 'Orden actualizado correctamente',
+        result: result,
+      })
+    } catch (error) {
+      handleErrors({ error, res })
+    }
+  }
+
   export = async (req: Request, res: Response) => {
     try {
       const { format } = req.params

--- a/src/routes/products/index.ts
+++ b/src/routes/products/index.ts
@@ -18,6 +18,7 @@ export const productsRouter = () => {
   router.get('/export/:format', controller.export)
   router.post('/', controller.create)
   router.patch('/order', controller.updateOrder)
+  router.patch('/orderManual/:id', controller.updateOrderManual)
   router.patch('/:id', controller.update)
   router.delete('/:id', controller.delete)
 


### PR DESCRIPTION
Add new PATCH /orderManual/:id endpoint to update single product display order. Implements transaction-safe order adjustment that automatically shifts other products' orders when moving a product up or down in the display sequence.