### PR TITLE
fix(products): update image order endpoint to include productId in path

### DIFF
--- a/src/controllers/products/images/index.ts
+++ b/src/controllers/products/images/index.ts
@@ -58,6 +58,7 @@ export class ProductImagesController {
 
   updateOrder = async (req: Request, res: Response) => {
     try {
+      const { productId } = req.params
       const { updatedImages } = req.body
 
       if (!Array.isArray(updatedImages)) {
@@ -68,21 +69,17 @@ export class ProductImagesController {
       }
 
       const hasInvalidItem = updatedImages.some(
-        (item) =>
-          typeof item.id !== 'string' ||
-          typeof item.productId !== 'string' ||
-          typeof item.displayOrder !== 'number',
+        (item) => typeof item.id !== 'string' || typeof item.displayOrder !== 'number',
       )
 
       if (hasInvalidItem) {
         res.status(400).json({
-          error:
-            'Cada imagen debe tener un "id" (string), "productId" (string) y un "displayOrder" (number)',
+          error: 'Cada imagen debe tener un "id" (string) y un "displayOrder" (number)',
         })
         return
       }
 
-      const result = await this.model.updateOrder(updatedImages)
+      const result = await this.model.updateOrder(productId, updatedImages)
 
       res.status(200).json({ message: 'Orden actualizado correctamente', images: result })
       return

--- a/src/models/Product/Images/index.ts
+++ b/src/models/Product/Images/index.ts
@@ -91,12 +91,13 @@ export class ProductImagesModel {
   }
 
   static async updateOrder(
+    productId: string,
     updatedImages: { id: string; productId: string; displayOrder: number }[],
   ) {
     try {
       const updateOperations = updatedImages.map((image) =>
         prisma.image.update({
-          where: { id: image.id, productId: image.productId },
+          where: { id: image.id, productId },
           data: { displayOrder: image.displayOrder },
         }),
       )

--- a/src/routes/products/images.ts
+++ b/src/routes/products/images.ts
@@ -25,7 +25,7 @@ export const createProductImagesRouter = () => {
     },
     controller.create,
   )
-  router.patch('/order', controller.updateOrder)
+  router.patch('/order/:productId', controller.updateOrder)
   // router.patch('/:id', controller.update)
   router.delete('/:imageId/:productId', controller.delete)
 


### PR DESCRIPTION
Update the image order endpoint to require productId in the URL path instead of in the request body for better RESTful practices. Simplify validation by removing redundant productId checks in the request body since it's now obtained from the path parameter.