### PR TITLE
fix(shipping): change shipping route to use userId param instead of a…

### DIFF
--- a/src/controllers/shippings/index.ts
+++ b/src/controllers/shippings/index.ts
@@ -12,9 +12,9 @@ export class ShippingController {
   }
 
   getAll = async (req: Request, res: Response) => {
-    const { user } = req
+    const { userId } = req.params
     try {
-      const objects = await this.model.getAll({ userId: user?.id })
+      const objects = await this.model.getAll({ userId })
       res.json(objects)
     } catch (error) {
       handleErrors({ error, res })

--- a/src/routes/shipping.ts
+++ b/src/routes/shipping.ts
@@ -9,7 +9,7 @@ export const shippingRouter = () => {
 
   router.use(requireAuth)
 
-  router.get('/', controller.getAll)
+  router.get('/:userId', controller.getAll)
   router.post('/', controller.create)
   router.patch('/:id', controller.update)
   router.delete('/:id', controller.delete)


### PR DESCRIPTION
…uth user

The getAll endpoint now accepts userId as a route parameter rather than using the authenticated user's ID. This allows fetching shipping data for specific users when needed.