### PR TITLE
feat(orders): add endpoint to get orders by user id

### DIFF
--- a/src/controllers/orders/index.ts
+++ b/src/controllers/orders/index.ts
@@ -16,14 +16,10 @@ export class OrderController {
     this.model = model
   }
 
-  getAll = async (req: Request, res: Response) => {
-    const { user } = req
+  getAllByUser = async (req: Request, res: Response) => {
+    const { userId } = req.params
     try {
-      if (!user) {
-        res.status(401).json({ error: 'Usuario no autenticado' })
-        return
-      }
-      const objects = await this.model.getAll({ userId: user.id })
+      const objects = await this.model.getAllByUser({ userId })
       res.status(200).send(objects)
     } catch (error) {
       handleErrors({ error, res })

--- a/src/models/Order/index.ts
+++ b/src/models/Order/index.ts
@@ -5,7 +5,7 @@ import { Prisma, PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient()
 
 export class OrderModel {
-  static async getAll({ userId }: { userId: string }) {
+  static async getAllByUser({ userId }: { userId: string }) {
     try {
       const orders = await prisma.order.findMany({
         where: { userId },
@@ -114,6 +114,24 @@ export class OrderModel {
           user: {
             connect: { id: userId },
           },
+        },
+        include: {
+          shipping: true,
+          items: {
+            select: {
+              id: true,
+              productId: true,
+              quantity: true,
+              price: true,
+              product: {
+                select: {
+                  name: true,
+                  images: true,
+                },
+              },
+            },
+          },
+          coupon: true,
         },
       })
 

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -8,7 +8,7 @@ export const ordersRouter = () => {
   const controller = new OrderController({ model: OrderModel })
 
   router.use(requireAuth)
-  router.get('/', controller.getAll)
+  router.get('/:userId', controller.getAllByUser)
   router.get('/:id', controller.getOrderById)
   router.post('/', controller.create)
 

--- a/src/schemas/orders/index.ts
+++ b/src/schemas/orders/index.ts
@@ -1,38 +1,5 @@
 import { z } from 'zod'
 
-/**
- Request Body example for creating an order:
- {
-  id: 'ORD-20250707183547475003',
-  couponCode: 'THEJUNIOR777',
-  shippingAddressId: '3cb0aa02-76bc-4e36-8106-fe888cb631ee',
-  products: [
-    {
-      id: 'cdd21c8e-aad0-4c08-b50f-9e1940738590',
-      quantity: 2,
-      price: 1.5,
-      categoryId: '336637b8-db87-44a9-af10-8b91d2014120'
-    },
-    {
-      id: '4e0be9d7-2eec-40ca-9f9d-a7d77b7c8ca4',
-      quantity: 2,
-      price: 0.7,
-      categoryId: '7f06025d-98d3-4bbd-8c48-74d4df92f317'
-    },
-    {
-      id: '22f7026f-e92e-423c-8958-041dc41c055d',
-      quantity: 6,
-      price: 35,
-      categoryId: '80f2388d-35a5-41eb-a6e9-97debc85d762'
-    }
-  ],
-  subtotal: 192.96,
-  discount: 21.44,
-  tax: 23.16,
-  total: 216.12
-}
- */
-
 export const OrderCreateSchema = z.object({
   id: z.string().regex(/^ORD-\d{20}$/),
   couponId: z.string().optional(),


### PR DESCRIPTION
Add new endpoint `/orders/:userId` to fetch orders for a specific user. Includes related shipping, items, and coupon data in the response. Removes the old `/orders` endpoint which required authentication and used the session user ID.