### PR TITLE
feat(order): add payment status field to order model

### DIFF
--- a/prisma/migrations/20250809181541_add_payment_status_to_order_model/migration.sql
+++ b/prisma/migrations/20250809181541_add_payment_status_to_order_model/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "public"."PaymentStatus" AS ENUM ('PENDING', 'PAID', 'REFUNDED', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "public"."Order" ADD COLUMN     "paymentStatus" "public"."PaymentStatus" NOT NULL DEFAULT 'PENDING';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,17 +144,18 @@ model ShippingAddress {
 }
 
 model Order {
-  id         String      @id
-  userId     String
-  shippingId String?
-  couponId   String?
-  tax        Decimal     @default(0.0) @db.Decimal(10, 2)
-  subtotal   Decimal     @default(0.0) @db.Decimal(10, 2)
-  discount   Decimal     @default(0.0) @db.Decimal(10, 2)
-  total      Decimal     @default(0.0) @db.Decimal(10, 2)
-  status     OrderStatus @default(PENDING)
-  createdAt  DateTime    @default(now())
-  updatedAt  DateTime    @updatedAt
+  id            String        @id
+  userId        String
+  shippingId    String?
+  couponId      String?
+  tax           Decimal       @default(0.0) @db.Decimal(10, 2)
+  subtotal      Decimal       @default(0.0) @db.Decimal(10, 2)
+  discount      Decimal       @default(0.0) @db.Decimal(10, 2)
+  total         Decimal       @default(0.0) @db.Decimal(10, 2)
+  status        OrderStatus   @default(PENDING)
+  paymentStatus PaymentStatus @default(PENDING)
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
 
   user     User             @relation(fields: [userId], references: [id], onDelete: Cascade, name: "UserOrders")
   shipping ShippingAddress? @relation(fields: [shippingId], references: [pk], onDelete: Cascade, name: "OrderShipping")
@@ -186,4 +187,11 @@ enum OrderStatus {
   DELIVERED
   CANCELLED
   RETURNED
+}
+
+enum PaymentStatus {
+  PENDING
+  PAID
+  REFUNDED
+  FAILED
 }


### PR DESCRIPTION
Introduce PaymentStatus enum and add paymentStatus field to Order model with default value 'PENDING' to track payment state of orders