### PR TITLE
feat(orders): add payment receipt upload functionality

### DIFF
--- a/prisma/migrations/20250824192739_add_payment_model/migration.sql
+++ b/prisma/migrations/20250824192739_add_payment_model/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `paymentStatus` on the `Order` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[orderPaymentId]` on the table `Order` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Order" DROP COLUMN "paymentStatus",
+ADD COLUMN     "orderPaymentId" TEXT;
+
+-- CreateTable
+CREATE TABLE "public"."OrderPayment" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "status" "public"."PaymentStatus" NOT NULL DEFAULT 'PENDING',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrderPayment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrderPayment_orderId_key" ON "public"."OrderPayment"("orderId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Order_orderPaymentId_key" ON "public"."Order"("orderPaymentId");
+
+-- AddForeignKey
+ALTER TABLE "public"."Order" ADD CONSTRAINT "Order_orderPaymentId_fkey" FOREIGN KEY ("orderPaymentId") REFERENCES "public"."OrderPayment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250824193400_add_receipt_field/migration.sql
+++ b/prisma/migrations/20250824193400_add_receipt_field/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `receipt` to the `Order` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Order" ADD COLUMN     "receipt" VARCHAR(800) NOT NULL;

--- a/prisma/migrations/20250824193512_reasign_receipt_field/migration.sql
+++ b/prisma/migrations/20250824193512_reasign_receipt_field/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `receipt` on the `Order` table. All the data in the column will be lost.
+  - Added the required column `receipt` to the `OrderPayment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "public"."Order" DROP COLUMN "receipt";
+
+-- AlterTable
+ALTER TABLE "public"."OrderPayment" ADD COLUMN     "receipt" VARCHAR(800) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -144,24 +144,25 @@ model ShippingAddress {
 }
 
 model Order {
-  id            String        @id
-  userId        String
-  shippingId    String?
-  couponId      String?
-  tax           Decimal       @default(0.0) @db.Decimal(10, 2)
-  subtotal      Decimal       @default(0.0) @db.Decimal(10, 2)
-  discount      Decimal       @default(0.0) @db.Decimal(10, 2)
-  total         Decimal       @default(0.0) @db.Decimal(10, 2)
-  status        OrderStatus   @default(PENDING)
-  paymentStatus PaymentStatus @default(PENDING)
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt
+  id        String      @id
+  tax       Decimal     @default(0.0) @db.Decimal(10, 2)
+  subtotal  Decimal     @default(0.0) @db.Decimal(10, 2)
+  discount  Decimal     @default(0.0) @db.Decimal(10, 2)
+  total     Decimal     @default(0.0) @db.Decimal(10, 2)
+  status    OrderStatus @default(PENDING)
+  createdAt DateTime    @default(now())
+  updatedAt DateTime    @updatedAt
+
+  userId         String
+  shippingId     String?
+  couponId       String?
+  orderPaymentId String? @unique
 
   user     User             @relation(fields: [userId], references: [id], onDelete: Cascade, name: "UserOrders")
   shipping ShippingAddress? @relation(fields: [shippingId], references: [pk], onDelete: Cascade, name: "OrderShipping")
   coupon   Coupon?          @relation(fields: [couponId], references: [id], onDelete: SetNull, name: "OrderCoupon")
-
-  items OrderItem[] @relation("OrderItems")
+  payment  OrderPayment?    @relation(name: "OrderPayment", fields: [orderPaymentId], references: [id], onDelete: SetNull)
+  items    OrderItem[]      @relation("OrderItems")
 
   @@index([userId])
 }
@@ -178,6 +179,17 @@ model OrderItem {
   product Product @relation(fields: [productId], references: [id], onDelete: Cascade, name: "OrderItemProduct")
 
   @@index([orderId])
+}
+
+model OrderPayment {
+  id        String        @id @default(uuid())
+  orderId   String        @unique
+  status    PaymentStatus @default(PENDING)
+  receipt   String        @db.VarChar(800)
+  createdAt DateTime      @default(now())
+  updatedAt DateTime      @updatedAt
+
+  order Order? @relation("OrderPayment")
 }
 
 enum OrderStatus {

--- a/src/models/Order/index.ts
+++ b/src/models/Order/index.ts
@@ -1,5 +1,11 @@
-import { OrderCreateType } from '@/schemas/orders'
-import { AppError, ConflictError, NotFoundError, ServerError } from '@/utils/errors'
+import { OrderCreateType, RegisterPaymentType } from '@/schemas/orders'
+import {
+  AppError,
+  ConflictError,
+  NotFoundError,
+  ServerError,
+  ValidationError,
+} from '@/utils/errors'
 import { Prisma, PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
@@ -34,6 +40,7 @@ const include = {
       lastName: true,
     },
   },
+  payment: true,
 }
 
 export class OrderModel {
@@ -41,7 +48,7 @@ export class OrderModel {
     try {
       const orders = await prisma.order.findMany({
         orderBy: [{ createdAt: 'desc' }],
-        include: include,
+        include,
       })
 
       if (!orders || orders.length === 0) throw new NotFoundError('No se encontraron órdenes')
@@ -181,6 +188,42 @@ export class OrderModel {
       }
       if (error instanceof AppError) throw error
       throw new ServerError('Error al intentar crear la orden')
+    }
+  }
+
+  static async createPayment({
+    orderId,
+    userId,
+    data,
+  }: {
+    orderId: string
+    userId: string
+    data: RegisterPaymentType
+  }) {
+    try {
+      const { receipt } = data
+      const order = await prisma.order.findUnique({
+        where: {
+          id: orderId,
+          userId,
+        },
+      })
+      if (!order) throw new NotFoundError('Orden no encontrada')
+      if (!receipt) throw new NotFoundError('Debes subir al menos una imagen.')
+
+      if (order.orderPaymentId) throw new ValidationError('La orden ya tiene un pago registrado')
+      return await prisma.orderPayment.create({
+        data: {
+          orderId: order.id,
+          receipt: receipt.key,
+          order: {
+            connect: { id: order.id },
+          },
+        },
+      })
+    } catch (error) {
+      if (error instanceof AppError) throw error
+      throw new ServerError('Error al intentar registrar el pago')
     }
   }
 }

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,6 +1,7 @@
 import { OrderController } from '@/controllers/orders'
 import { requireAuth, requireRole } from '@/middlewares/auth'
 import { OrderModel } from '@/models/Order'
+import { getMulterS3OrderUpload } from '@/utils/s3/s3Uploader'
 import { Router } from 'express'
 
 export const ordersRouter = () => {
@@ -10,6 +11,22 @@ export const ordersRouter = () => {
   router.use(requireAuth)
   router.get('/:userId', controller.getAllByUser)
   router.get('/:id', controller.getOrderById)
+  router.post(
+    '/:userId/:orderId',
+    async (req, res, next) => {
+      const { orderId } = req.params
+      const upload = getMulterS3OrderUpload(orderId).single('receipt')
+
+      upload(req, res, (err) => {
+        if (err) {
+          res.status(500).json({ error: err.message })
+          return
+        }
+        next()
+      })
+    },
+    controller.createPayment,
+  )
   router.post('/', controller.create)
 
   router.use(requireRole)

--- a/src/routes/products/images.ts
+++ b/src/routes/products/images.ts
@@ -1,6 +1,6 @@
 import { ProductImagesController } from '@/controllers/products/images'
 import { ProductImagesModel } from '@/models/Product/Images'
-import { getMulterS3Upload } from '@/utils/s3/s3Uploader'
+import { getMulterS3ProductUpload } from '@/utils/s3/s3Uploader'
 import { Router } from 'express'
 
 export const createProductImagesRouter = () => {
@@ -13,7 +13,7 @@ export const createProductImagesRouter = () => {
     '/:productId',
     async (req, res, next) => {
       const productId = req.params.productId
-      const upload = getMulterS3Upload(productId).array('files')
+      const upload = getMulterS3ProductUpload(productId).array('files')
 
       upload(req, res, (err) => {
         if (err) {

--- a/src/schemas/orders/index.ts
+++ b/src/schemas/orders/index.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+const MAX_FILE_SIZE = 1024 * 1024 * 5
+const ACCEPTED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/jpg', 'image/png']
+
 export const OrderCreateSchema = z.object({
   id: z.string().regex(/^ORD-\d{20}$/),
   couponId: z.string().optional(),
@@ -29,9 +32,26 @@ export const OrderUpdateSchema = OrderCreateSchema.partial().omit({
   total: true,
 })
 
+export const RegisterPaymentSchema = z.object({
+  receipt: z.object({
+    mimetype: z.string().refine((type) => ACCEPTED_IMAGE_MIME_TYPES.includes(type), {
+      message: 'Solo los formatos .jpg, .jpeg y .png están permitidos.',
+    }),
+    size: z.number().max(MAX_FILE_SIZE, { message: 'La imagen debe ser de 5MB o menos' }),
+    key: z.string(),
+    originalname: z.string(),
+    location: z.string(),
+  }),
+})
+
 export type OrderCreateType = z.infer<typeof OrderCreateSchema>
 export type OrderUpdateType = z.infer<typeof OrderUpdateSchema>
+export type RegisterPaymentType = z.infer<typeof RegisterPaymentSchema>
 
 export const validateOrderCreate = (order: OrderCreateType) => {
   return OrderCreateSchema.safeParse(order)
+}
+
+export const validatePaymentCreate = (data: RegisterPaymentType) => {
+  return RegisterPaymentSchema.safeParse(data)
 }

--- a/src/utils/s3/s3UploadPath.ts
+++ b/src/utils/s3/s3UploadPath.ts
@@ -18,3 +18,12 @@ export function getProductImageS3Key(productSlug: string, filename: string) {
   const key = `media/Product/${productSlug}/Images/${safeName}.${ext}`
   return key
 }
+
+export function getOrderPaymentImageS3Key(createdAtString: string, file: Express.Multer.File) {
+  const ext = file.mimetype.split('/')[1]
+  const baseName = file.originalname.replace(/\.[^/.]+$/, '')
+  const safeName = slugify(baseName)
+
+  const key = `media/Order/${createdAtString}/${safeName}.${ext}`
+  return key
+}


### PR DESCRIPTION
## Desccription
- Create `OrderPayment` model and migration.
- Implement `S3 upload` for order payment receipts.
- Add endpoint for uploading payment receipts.
- Validate receipt file type and size.
- Update order schema to include payment relation.